### PR TITLE
Added getItemId

### DIFF
--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/adapters/AnimationAdapter.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/adapters/AnimationAdapter.java
@@ -94,4 +94,9 @@ public abstract class AnimationAdapter extends RecyclerView.Adapter<RecyclerView
   public RecyclerView.Adapter<RecyclerView.ViewHolder> getWrappedAdapter() {
     return mAdapter;
   }
+  
+  @Override
+  public long getItemId(int position) {
+        return mAdapter.getItemId(position);
+  }
 }


### PR DESCRIPTION
Fixed the `getItemId()` to return the nested adapter item id