### PR TITLE
Implement Hierarchical Timing specification for all animators in accordance with Google Material Design motion guidelines

### DIFF
--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/BaseItemAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/BaseItemAnimator.java
@@ -245,11 +245,20 @@ public abstract class BaseItemAnimator extends SimpleItemAnimator {
     return true;
   }
 
+  protected long getRemoveDelay(final RecyclerView.ViewHolder holder) {
+    return Math.abs(holder.getOldPosition() * getRemoveDuration() / 4);
+  }
+
   @Override public boolean animateAdd(final ViewHolder holder) {
     endAnimation(holder);
     preAnimateAdd(holder);
     mPendingAdditions.add(holder);
     return true;
+  }
+
+
+  protected long getAddDelay(final RecyclerView.ViewHolder holder) {
+    return Math.abs(holder.getAdapterPosition() * getAddDuration() / 4);
   }
 
   @Override

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInAnimator.java
@@ -35,6 +35,7 @@ public class FadeInAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -48,6 +49,7 @@ public class FadeInAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInDownAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInDownAnimator.java
@@ -36,6 +36,7 @@ public class FadeInDownAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -51,6 +52,7 @@ public class FadeInDownAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInLeftAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInLeftAnimator.java
@@ -36,6 +36,7 @@ public class FadeInLeftAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -51,6 +52,7 @@ public class FadeInLeftAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInRightAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInRightAnimator.java
@@ -36,6 +36,7 @@ public class FadeInRightAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -51,6 +52,7 @@ public class FadeInRightAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInUpAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FadeInUpAnimator.java
@@ -36,6 +36,7 @@ public class FadeInUpAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -51,6 +52,7 @@ public class FadeInUpAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInBottomXAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInBottomXAnimator.java
@@ -35,6 +35,7 @@ public class FlipInBottomXAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -48,6 +49,7 @@ public class FlipInBottomXAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInLeftYAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInLeftYAnimator.java
@@ -35,6 +35,7 @@ public class FlipInLeftYAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -48,6 +49,7 @@ public class FlipInLeftYAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInRightYAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInRightYAnimator.java
@@ -35,6 +35,7 @@ public class FlipInRightYAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -48,6 +49,7 @@ public class FlipInRightYAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInTopXAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/FlipInTopXAnimator.java
@@ -35,6 +35,7 @@ public class FlipInTopXAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -48,6 +49,7 @@ public class FlipInTopXAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/LandingAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/LandingAnimator.java
@@ -37,6 +37,7 @@ public class LandingAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -54,6 +55,7 @@ public class LandingAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/OvershootInLeftAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/OvershootInLeftAnimator.java
@@ -37,6 +37,7 @@ public class OvershootInLeftAnimator extends BaseItemAnimator {
         .translationX(-holder.itemView.getRootView().getWidth())
         .setDuration(getRemoveDuration())
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -50,6 +51,7 @@ public class OvershootInLeftAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setListener(new DefaultAddVpaListener(holder))
         .setInterpolator(new OvershootInterpolator(mTension))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/OvershootInRightAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/OvershootInRightAnimator.java
@@ -37,6 +37,7 @@ public class OvershootInRightAnimator extends BaseItemAnimator {
         .translationX(holder.itemView.getRootView().getWidth())
         .setDuration(getRemoveDuration())
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -50,6 +51,7 @@ public class OvershootInRightAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(new OvershootInterpolator(mTension))
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInAnimator.java
@@ -36,9 +36,10 @@ public class ScaleInAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
-        .setStartDelay(holder.getAdapterPosition() * getRemoveDuration() / 4)
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
+
 
   @Override protected void preAnimateAddImpl(RecyclerView.ViewHolder holder) {
     ViewCompat.setScaleX(holder.itemView, 0);
@@ -52,7 +53,7 @@ public class ScaleInAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
-        .setStartDelay(holder.getAdapterPosition() * getAddDuration() / 4)
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInAnimator.java
@@ -36,6 +36,7 @@ public class ScaleInAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(holder.getAdapterPosition() * getRemoveDuration() / 4)
         .start();
   }
 
@@ -51,6 +52,7 @@ public class ScaleInAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(holder.getAdapterPosition() * getAddDuration() / 4)
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInBottomAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInBottomAnimator.java
@@ -42,6 +42,7 @@ public class ScaleInBottomAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -60,6 +61,7 @@ public class ScaleInBottomAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInLeftAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInLeftAnimator.java
@@ -40,6 +40,7 @@ public class ScaleInLeftAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -56,6 +57,7 @@ public class ScaleInLeftAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInRightAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInRightAnimator.java
@@ -40,6 +40,7 @@ public class ScaleInRightAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -56,6 +57,7 @@ public class ScaleInRightAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInTopAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/ScaleInTopAnimator.java
@@ -42,6 +42,7 @@ public class ScaleInTopAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -60,6 +61,7 @@ public class ScaleInTopAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInDownAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInDownAnimator.java
@@ -37,6 +37,7 @@ public class SlideInDownAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -52,6 +53,7 @@ public class SlideInDownAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInLeftAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInLeftAnimator.java
@@ -36,7 +36,7 @@ public class SlideInLeftAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
-        .setStartDelay(holder.getAdapterPosition() * getRemoveDuration())
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -50,7 +50,7 @@ public class SlideInLeftAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
-        .setStartDelay(holder.getAdapterPosition() * getAddDuration())
+        .setStartDelay(getAddDelay(holder))
         .start();
 }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInLeftAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInLeftAnimator.java
@@ -36,6 +36,7 @@ public class SlideInLeftAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(holder.getAdapterPosition() * getRemoveDuration())
         .start();
   }
 
@@ -49,6 +50,7 @@ public class SlideInLeftAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(holder.getAdapterPosition() * getAddDuration())
         .start();
-  }
+}
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInRightAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInRightAnimator.java
@@ -36,7 +36,7 @@ public class SlideInRightAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
-        .setStartDelay(holder.getAdapterPosition() * getRemoveDuration())
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -50,7 +50,7 @@ public class SlideInRightAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
-        .setStartDelay(holder.getAdapterPosition() * getAddDuration())
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInRightAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInRightAnimator.java
@@ -36,6 +36,7 @@ public class SlideInRightAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(holder.getAdapterPosition() * getRemoveDuration())
         .start();
   }
 
@@ -49,6 +50,7 @@ public class SlideInRightAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(holder.getAdapterPosition() * getAddDuration())
         .start();
   }
 }

--- a/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInUpAnimator.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/animators/SlideInUpAnimator.java
@@ -37,6 +37,7 @@ public class SlideInUpAnimator extends BaseItemAnimator {
         .setDuration(getRemoveDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultRemoveVpaListener(holder))
+        .setStartDelay(getRemoveDelay(holder))
         .start();
   }
 
@@ -52,6 +53,7 @@ public class SlideInUpAnimator extends BaseItemAnimator {
         .setDuration(getAddDuration())
         .setInterpolator(mInterpolator)
         .setListener(new DefaultAddVpaListener(holder))
+        .setStartDelay(getAddDelay(holder))
         .start();
   }
 }


### PR DESCRIPTION
# Goal 
Adhere to the Google Material Design Hierarchical Timing spec, [illustrated in this video](https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B08MbvYZK1iNTGRLb2Zud2RUNFE/animation-meaningfultransitions-hierarchicaltiming-4do_large_xhdpi.webm).

# Motivation
[The Google Material Design spec for recycler view animations](
https://www.google.com/design/spec/animation/meaningful-transitions.html#meaningful-transitions-hierarchical-timing) specifies:
> When building a transition, consider the order and timing of element movement. Ensure that motion supports the information hierarchy, conveying what content is most important by creating a path for the eye to follow.
recyclerview-animators does not currently follow this specification - all elements animate in at once. 

# Pull Request
In this PR, I've implemented the Hierarchical Timing specification for all animators, achieving the cool effect that the spec video shows.

Here's a video of my implementation in action, in my app:
https://www.dropbox.com/s/gxiw63pn7ljv3if/recyclerview-animation.mp4?dl=0

# Implementation details
I achieved this by adding a `.setStartDelay` call to each Animator's `animateAddImpl` and `animateRemoveImpl` method. They call two new methods on `BaseAnimator`: `getAddDelay` and `getRemoveDelay` respectively. These methods will determine the delay based on:
 1. the element's position in the adapter
 2. the current add or remove duration set by `.setAddDuration` or `setRemoveDuration` (currently, this is retrieved and then divided by 4 - I found this gives the best result and provides smooth, overlapping animations that are closest to the spec video.)

Let me know if you need more information to merge this. Thanks for the great library!