### PR TITLE
Dispatch onViewRecycled event to wrapped adapter

### DIFF
--- a/animators/src/main/java/jp/wasabeef/recyclerview/adapters/AnimationAdapter.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/adapters/AnimationAdapter.java
@@ -65,6 +65,11 @@ public abstract class AnimationAdapter extends RecyclerView.Adapter<RecyclerView
     }
   }
 
+  @Override public void onViewRecycled(RecyclerView.ViewHolder holder) {
+    mAdapter.onViewRecycled(holder);
+    super.onViewRecycled(holder);
+  }
+
   @Override public int getItemCount() {
     return mAdapter.getItemCount();
   }


### PR DESCRIPTION
Dispatching this event allows wrapped adapter to clean up any heavy
resources, such as images, when the view is recycled.