### PR TITLE
Fix setStartDelay() is not reset by clear()

### DIFF
--- a/animators/src/main/java/jp/wasabeef/recyclerview/internal/ViewHelper.java
+++ b/animators/src/main/java/jp/wasabeef/recyclerview/internal/ViewHelper.java
@@ -32,6 +32,8 @@ public final class ViewHelper {
     ViewCompat.setRotationX(v, 0);
     ViewCompat.setPivotY(v, v.getMeasuredHeight() / 2);
     ViewCompat.setPivotX(v, v.getMeasuredWidth() / 2);
-    ViewCompat.animate(v).setInterpolator(null);
+    ViewCompat.animate(v)
+            .setInterpolator(null)
+            .setStartDelay(0);
   }
 }


### PR DESCRIPTION
Particular item views occasionally blinks on notifyDataSetChanged(), when smoothScrollToPosition() is called repeatedly before animation in animateAddImpl() finishes.

This was because start delay value is not reset on cancel of animation.

Refer #66

Thanks!