### PR TITLE
Update README Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,22 @@ Please feel free to use this.
 
 #### Gradle
 
+On your module's `build.gradle` file add this compile statement to the `dependencies` section:
+
 ```groovy
 dependencies {
-  // jCenter
   compile 'jp.wasabeef:recyclerview-animators:2.2.7'
+}
+```
+
+Also make sure that the `repositories` section includes not only jcenter but also a `maven` section with the `"https://maven.google.com"` endpoint. 
+
+```
+repositories {
+  jcenter()
+  maven {
+    url "https://maven.google.com"
+  }
 }
 ```
 


### PR DESCRIPTION
This project depends on revision 25.4.0 of support libraries. Starting from this version, libraries are now installed using Google's Maven repository, so it is now necessary to have that repository listed in your gradle config or else android studio will throw errors when trying to add recyclerview-animations a project.